### PR TITLE
Tratar erro API Rastreio

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.0.23-BETA
+version=0.0.24-BETA

--- a/src/main/java/br/com/correios/api/rastreio/model/ObjetoRastreio.java
+++ b/src/main/java/br/com/correios/api/rastreio/model/ObjetoRastreio.java
@@ -1,5 +1,6 @@
 package br.com.correios.api.rastreio.model;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 import java.util.ArrayList;
@@ -82,8 +83,8 @@ public class ObjetoRastreio {
 		this.categoria = categoria;
 	}
 
-	public String getDescricaoErro() {
-		return descricaoErro;
+	public Optional<String> getDescricaoErro() {
+		return Optional.fromNullable(defaultIfBlank(descricaoErro, null));
 	}
 
 	public void setDescricaoErro(String descricaoErro) {

--- a/src/main/java/br/com/correios/api/rastreio/service/SoapCorreiosServicoRastreioApi.java
+++ b/src/main/java/br/com/correios/api/rastreio/service/SoapCorreiosServicoRastreioApi.java
@@ -66,11 +66,15 @@ class SoapCorreiosServicoRastreioApi implements CorreiosServicoRastreioApi {
 		}
 
 		List<ObjetoRastreio> objetosRastreio = detalhesRastreio.getObjetosRastreio();
-		if (!objetosRastreio.isEmpty() && StringUtils.isNotBlank(objetosRastreio.get(0).getDescricaoErro())) {
-			throw new CorreiosServicoSoapException(String.format("Ocorreu um erro ao fazer a chamada SOAP para os correios: %s", objetosRastreio.get(0).getDescricaoErro()));
+		if (temErroGenerico(objetosRastreio)) {
+			throw new CorreiosServicoSoapException(String.format("Ocorreu um erro ao fazer a chamada SOAP para os correios: %s", objetosRastreio.get(0).getDescricaoErro().get()));
 		}
 
 		return detalhesRastreio;
+	}
+
+	private boolean temErroGenerico(List<ObjetoRastreio> objetosRastreio) {
+		return objetosRastreio.size() == 1 && StringUtils.equals(objetosRastreio.get(0).getNumero(), "Erro");
 	}
 
 }

--- a/src/test/java/br/com/correios/api/converter/EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest.java
+++ b/src/test/java/br/com/correios/api/converter/EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest.java
@@ -53,7 +53,7 @@ public class EventosDosCorreiosToPacoteRastreadoDetalhesConverterTest {
 		assertThat(objetoRastreio.getNome()).isEqualTo("Encomenda E-SEDEX");
 		assertThat(objetoRastreio.getNumero()).isEqualTo("123456789");
 		assertThat(objetoRastreio.getSigla()).isEqualTo("DU");
-		assertThat(objetoRastreio.getDescricaoErro()).isEqualTo("Erro aqui");
+		assertThat(objetoRastreio.getDescricaoErro().get()).isEqualTo("Erro aqui");
 	}
 
 	@Test


### PR DESCRIPTION
## Changelog

- Lançar exceção somente quando houver erro genérico
- Quando houver busca de vários objetos, cada objeto pode trazer sua descrição de erro, caso exista